### PR TITLE
Update loadRefreshToken method to fix osin breaking changes from 2014

### DIFF
--- a/mgostore/mgostorage.go
+++ b/mgostore/mgostorage.go
@@ -1,46 +1,47 @@
 package mgostore
 
 import (
-    "github.com/RangelReale/osin"
+	"github.com/RangelReale/osin"
 
 	"encoding/json"
-    "gopkg.in/mgo.v2"
-    "gopkg.in/mgo.v2/bson"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // collection names for the entities
 const (
-    CLIENT_COL    = "clients"
-    AUTHORIZE_COL = "authorizations"
-    ACCESS_COL    = "accesses"
+	CLIENT_COL    = "clients"
+	AUTHORIZE_COL = "authorizations"
+	ACCESS_COL    = "accesses"
 )
 
 const REFRESHTOKEN = "refreshtoken"
 
 type MongoStorage struct {
-    dbName  string
-    session *mgo.Session
+	dbName  string
+	session *mgo.Session
 }
 
 func New(session *mgo.Session, dbName string) *MongoStorage {
-    storage := &MongoStorage{dbName, session}
-    index := mgo.Index{
-        Key:        []string{REFRESHTOKEN},
-        Unique:     false, // refreshtoken is sometimes empty
-        DropDups:   false,
-        Background: true,
-        Sparse:     true,
-    }
-    accesses := storage.session.DB(dbName).C(ACCESS_COL)
-    err := accesses.EnsureIndex(index)
-    if err != nil {
-        panic(err)
-    }
-    return storage
+	storage := &MongoStorage{dbName, session}
+	index := mgo.Index{
+		Key:        []string{REFRESHTOKEN},
+		Unique:     false, // refreshtoken is sometimes empty
+		DropDups:   false,
+		Background: true,
+		Sparse:     true,
+	}
+	accesses := storage.session.DB(dbName).C(ACCESS_COL)
+	err := accesses.EnsureIndex(index)
+	if err != nil {
+		panic(err)
+	}
+	return storage
 }
 
 func (store *MongoStorage) Clone() osin.Storage {
-    return store
+	return store
 }
 
 func (store *MongoStorage) Close() {
@@ -48,34 +49,34 @@ func (store *MongoStorage) Close() {
 }
 
 func (store *MongoStorage) GetClient(id string) (osin.Client, error) {
-    session := store.session.Copy()
-    defer session.Close()
-    clients := session.DB(store.dbName).C(CLIENT_COL)
-    client := new(osin.DefaultClient)
-    err := clients.FindId(id).One(client)
-    return client, err
+	session := store.session.Copy()
+	defer session.Close()
+	clients := session.DB(store.dbName).C(CLIENT_COL)
+	client := new(osin.DefaultClient)
+	err := clients.FindId(id).One(client)
+	return client, err
 }
 
 func (store *MongoStorage) SetClient(id string, client osin.Client) error {
-    session := store.session.Copy()
-    defer session.Close()
-    clients := session.DB(store.dbName).C(CLIENT_COL)
-    _, err := clients.UpsertId(id, client)
-    return err
+	session := store.session.Copy()
+	defer session.Close()
+	clients := session.DB(store.dbName).C(CLIENT_COL)
+	_, err := clients.UpsertId(id, client)
+	return err
 }
 
 func (store *MongoStorage) SaveAuthorize(data *osin.AuthorizeData) error {
-    session := store.session.Copy()
-    defer session.Close()
-    authorizations := session.DB(store.dbName).C(AUTHORIZE_COL)
-    _, err := authorizations.UpsertId(data.Code, data)
-    return err
+	session := store.session.Copy()
+	defer session.Close()
+	authorizations := session.DB(store.dbName).C(AUTHORIZE_COL)
+	_, err := authorizations.UpsertId(data.Code, data)
+	return err
 }
 
 func (store *MongoStorage) LoadAuthorize(code string) (*osin.AuthorizeData, error) {
-    session := store.session.Copy()
-    defer session.Close()
-    authorizations := session.DB(store.dbName).C(AUTHORIZE_COL)
+	session := store.session.Copy()
+	defer session.Close()
+	authorizations := session.DB(store.dbName).C(AUTHORIZE_COL)
 	authData := osin.AuthorizeData{
 		Client: new(osin.DefaultClient),
 	}
@@ -91,55 +92,67 @@ func (store *MongoStorage) LoadAuthorize(code string) (*osin.AuthorizeData, erro
 
 	err = json.Unmarshal(j1, &authData)
 
-    return &authData, err
+	return &authData, err
 }
 
 func (store *MongoStorage) RemoveAuthorize(code string) error {
-    session := store.session.Copy()
-    defer session.Close()
-    authorizations := session.DB(store.dbName).C(AUTHORIZE_COL)
-    return authorizations.RemoveId(code)
+	session := store.session.Copy()
+	defer session.Close()
+	authorizations := session.DB(store.dbName).C(AUTHORIZE_COL)
+	return authorizations.RemoveId(code)
 }
 
 func (store *MongoStorage) SaveAccess(data *osin.AccessData) error {
-    session := store.session.Copy()
-    defer session.Close()
-    accesses := session.DB(store.dbName).C(ACCESS_COL)
-    _, err := accesses.UpsertId(data.AccessToken, data)
-    return err
+	session := store.session.Copy()
+	defer session.Close()
+	accesses := session.DB(store.dbName).C(ACCESS_COL)
+	_, err := accesses.UpsertId(data.AccessToken, data)
+	return err
 }
 
 func (store *MongoStorage) LoadAccess(token string) (*osin.AccessData, error) {
-    session := store.session.Copy()
-    defer session.Close()
-    accesses := session.DB(store.dbName).C(ACCESS_COL)
-    accData := new(osin.AccessData)
-    err := accesses.FindId(token).One(accData)
-    return accData, err
+	session := store.session.Copy()
+	defer session.Close()
+	accesses := session.DB(store.dbName).C(ACCESS_COL)
+	accData := new(osin.AccessData)
+	err := accesses.FindId(token).One(accData)
+	return accData, err
 }
 
 func (store *MongoStorage) RemoveAccess(token string) error {
-    session := store.session.Copy()
-    defer session.Close()
-    accesses := session.DB(store.dbName).C(ACCESS_COL)
-    return accesses.RemoveId(token)
+	session := store.session.Copy()
+	defer session.Close()
+	accesses := session.DB(store.dbName).C(ACCESS_COL)
+	return accesses.RemoveId(token)
 }
 
 func (store *MongoStorage) LoadRefresh(token string) (*osin.AccessData, error) {
-    session := store.session.Copy()
-    defer session.Close()
-    accesses := session.DB(store.dbName).C(ACCESS_COL)
-    accData := new(osin.AccessData)
-    err := accesses.Find(bson.M{REFRESHTOKEN: token}).One(accData)
-    return accData, err
-}
+	session := store.session.Copy()
+	defer session.Close()
+	accesses := session.DB(store.dbName).C(ACCESS_COL)
+	accData := osin.AccessData{Client: &osin.DefaultClient{}}
+	genericAccessData := make(bson.M)
+	if err := accesses.Find(bson.M{REFRESHTOKEN: token}).One(&genericAccessData); err != nil {
+		return &accData, err
+	}
 
+	j1, err := json.Marshal(genericAccessData)
+	if err != nil {
+		return &accData, err
+	}
+	err = json.Unmarshal(j1, &accData)
+	if err != nil {
+		return &accData, err
+	}
+
+	return &accData, err
+}
 func (store *MongoStorage) RemoveRefresh(token string) error {
-    session := store.session.Copy()
-    defer session.Close()
-    accesses := session.DB(store.dbName).C(ACCESS_COL)
-    return accesses.Update(bson.M{REFRESHTOKEN: token}, bson.M{
-        "$unset": bson.M{
-            REFRESHTOKEN: 1,
-        }})
+	session := store.session.Copy()
+	defer session.Close()
+	accesses := session.DB(store.dbName).C(ACCESS_COL)
+	return accesses.Update(bson.M{REFRESHTOKEN: token}, bson.M{
+		"$unset": bson.M{
+			REFRESHTOKEN: 1,
+		}})
 }


### PR DESCRIPTION
Change refresh token load to not break because of osin 2014 breaking changes.

Osin changes client from struct to type interface, which caused mgo to break when referencing client type interface. This change gets by that.